### PR TITLE
Alternative documentation using DataExtension instead of extending the Image class

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Clone/download this repository into a folder called "sortablefile" in your Silve
 Example setup
 -------------
 
-Let's assume we have a `PortfolioPage` that has multiple `Images`. Define the relation in an DataExtension:
+Let's assume we have a `PortfolioPage` that has multiple `Images`. Define the relation in a DataExtension:
 
     class ImageExtension extends DataExtension
     {
@@ -23,7 +23,8 @@ Let's assume we have a `PortfolioPage` that has multiple `Images`. Define the re
         );
     }
 
-We apply the `ImageExtension` to the `Image` class and enable sorting by adding the following lines to `mysite/_config.php` (run `dev/build` afterwards!):
+We apply the `ImageExtension` to the `Image` class   
+and enable sorting by adding the following lines to `mysite/_config.php` (run `dev/build` afterwards!):
 
     //apply the image extension
     Object::add_extension('Image', 'ImageExtension');


### PR DESCRIPTION
Hey,

just a suggestion for an alternative doc using DataExtension.

i'd prefer this over extending Image directly as your custom Image Type sometimes conflicts with the Images uploaded via the "Files" manager, resulting in not beeing able to select Images "from files" in the uploadfield anymore.

just my 2 cents, though :)

thanks for the plugin btw. used in an couple of projects already

cheers

Max
