### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "silverstripe/sortablefile",
+    "name": "bummzack/sortablefile",
     "description": "An extension for SilverStripe 3.0 that allows sorting of multiple attached images (extends UploadField).",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "CMS", "sortable"],


### PR DESCRIPTION
The first part of the Composer package name is supposed to indicate vendor, rather than the using it to indicate that this is a silverstripe module.

We're building a site that aggregates all the SilverStripe themes and modules (see http://extensions.andrewshort.name for a sneak peek) so we don't need to worry about them getting lost.

Creating your own vendor prefix minimises the change of naming conflicts, and will provide you a listing on http://extensions.andrewshort.name/vendors
