### PR TITLE
Bugfix: ManyManyList not sortable by sort() through a JOINED table

### DIFF
--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -153,6 +153,11 @@ class SortableUploadField_ItemHandler extends UploadField_ItemHandler
 			$newPosition = intval($newPosition);
 			$oldPosition = intval($oldPosition);
 			$arrayList = $list->toArray();
+			if ($is_many_many) {
+				// many_many_list not sortable
+				$arrayList = new ArrayList($arrayList);
+				$arrayList = $arrayList->sort($sortColumn, 'ASC');
+			}
 			$itemIsInList = false;
 			
 			foreach ($arrayList as $item) {


### PR DESCRIPTION
Sorting at line 148 does not work in a many_many relationship, resulting in an undefined behaviour. Sometimes it works, other it doesn't.
