### PR TITLE
Remove CMS dependency from composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
     ],
     "require":
     {
-        "silverstripe/framework": "~3.1",
-        "silverstripe/cms": "~3.1"
+        "silverstripe/framework": "~3.1"
     }
 }


### PR DESCRIPTION
I have removed the CMS requirement as it doesn't seem to be needed and would be nice to use this great module without the CMS?
