### PR TITLE
When an image is added to a has_many list, add the item and sort order.

### DIFF
--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -147,6 +147,7 @@ class SortableUploadField_ItemHandler extends UploadField_ItemHandler
 		if ($record && $record->hasMethod($relationName)) {
 			$list = $record->$relationName();
 			$list = $list->sort($sortColumn, 'ASC');
+			$listForeignKey = $list->getForeignKey();
 			
 			$is_many_many = $record->many_many($relationName) !== null;
 			
@@ -180,8 +181,16 @@ class SortableUploadField_ItemHandler extends UploadField_ItemHandler
 			}
 			
 			// if the item wasn't in our list, add it now with the new sort position
-			if(!$itemIsInList && $is_many_many){
-				$list->add($itemMoved, array($sortColumn => $newPosition + 1));
+			if(!$itemIsInList){
+				if ($is_many_many) {
+					$list->add($itemMoved, array($sortColumn => $newPosition + 1));
+				}
+				else
+				{
+					$itemMoved->$listForeignKey = $record->ID;
+					$itemMoved->$sortColumn = intval($newPosition + 1);
+					$itemMoved->write();
+				}
 			}
 			
 			Requirements::clear();


### PR DESCRIPTION
When an image is added to a has_many list and sorted, this sort order is lost when the page is saved. 

This update fixes this, just like the code currently does for a many_many list.

this commit fixes issue #24 