### PR TITLE
Setup more stable method for retrieving back-end "sort" action

### DIFF
--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -23,9 +23,9 @@ class SortableUploadField extends UploadField
 		if($this->getRecord() && $this->getRecord()->exists()){
 			$html = $htmlText->getValue();
 			$token = $this->getForm()->getSecurityToken();
-			$action = $token->addToUrl($this->getItemHandler("{id}")->Link("sort"));
-			// add the sort action to the field, use {id} as a subsitute for the ID
-			$html .= "<input type='hidden' id='{$this->ID()}_FileSortAction' class='sortableupload-sortaction' data-action='$action'>";
+			$action = Convert::raw2att($token->addToUrl($this->getItemHandler("{id}")->Link("sort")));
+			// add the sort action to the field, use {id} as a substitute for the ID
+			$html .= "<input type=\"hidden\" id=\"{$this->ID()}_FileSortAction\" class=\"sortableupload-sortaction\" data-action=\"$action\">";
 			$htmlText->setValue($html);
 		}
 

--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -11,42 +11,25 @@ class SortableUploadField extends UploadField
 	 */
 	protected $sortColumn = 'SortOrder';
 
-	/**
-	 * Keep track of files so we can drop extra information into the template via the ->Field() above. This is populated
-	 * via the ->customizeFile() method.
-	 *
-	 * @var File[]
-	 */
-	private $files = [];
-
 	public function Field($properties = array()) {
 		Requirements::javascript(THIRDPARTY_DIR . '/jquery-ui/jquery-ui.js');
 		Requirements::javascript(SORTABLEFILE_DIR . '/javascript/SortableUploadField.js');
 		Requirements::css(SORTABLEFILE_DIR . '/css/SortableUploadField.css');
 
-		$fieldID = $this->ID();
-
-		// Go through all files and setup a custom action link for each, including the security token (to authorize requests).
 		/** @var HTMLText $htmlText */
 		$htmlText = parent::Field($properties);
-		$html = $htmlText->getValue();
-		foreach($this->files as $file) {
+
+		// check if the record (to write into) exists. If not, there's no sort action to be used in the frontend
+		if($this->getRecord() && $this->getRecord()->exists()){
+			$html = $htmlText->getValue();
 			$token = $this->getForm()->getSecurityToken();
-			$action = $token->addToUrl($this->getItemHandler($file->ID)->Link("sort"));
-			$html .= "<input type='hidden' id='{$fieldID}_File_$file->ID' data-action='$action'>";
+			$action = $token->addToUrl($this->getItemHandler("{id}")->Link("sort"));
+			// add the sort action to the field, use {id} as a subsitute for the ID
+			$html .= "<input type='hidden' id='{$this->ID()}_FileSortAction' class='sortableupload-sortaction' data-action='$action'>";
+			$htmlText->setValue($html);
 		}
-		$htmlText->setValue($html);
 
 		return $htmlText;
-	}
-
-	/**
-	 * @param	File	$file
-	 * @return	ViewableData_Customised
-	 */
-	protected function customiseFile(File $file) {
-		$this->files[] = $file;
-		return parent::customiseFile($file);
 	}
 
 	/**

--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -24,6 +24,8 @@ class SortableUploadField extends UploadField
 		Requirements::javascript(SORTABLEFILE_DIR . '/javascript/SortableUploadField.js');
 		Requirements::css(SORTABLEFILE_DIR . '/css/SortableUploadField.css');
 
+		$fieldID = $this->ID();
+
 		// Go through all files and setup a custom action link for each, including the security token (to authorize requests).
 		/** @var HTMLText $htmlText */
 		$htmlText = parent::Field($properties);
@@ -31,7 +33,7 @@ class SortableUploadField extends UploadField
 		foreach($this->files as $file) {
 			$token = $this->getForm()->getSecurityToken();
 			$action = $token->addToUrl($this->getItemHandler($file->ID)->Link("sort"));
-			$html .= "<input type='hidden' id='SortableUploadField_File_$file->ID' data-action='$action'>";
+			$html .= "<input type='hidden' id='{$fieldID}_File_$file->ID' data-action='$action'>";
 		}
 		$htmlText->setValue($html);
 

--- a/javascript/SortableUploadField.js
+++ b/javascript/SortableUploadField.js
@@ -19,16 +19,23 @@
 							self.css("overflow", "auto");
 						},
 						update: function(event, ui){
+							// get the field ID from the actual upload field
+							var fieldID = $(this).parent().find("input.sortableupload").attr("id");
 							// Use the current file ID to determine a URL to the correct sort action handler.
 							var fileID = ui.item.data("fileid");
-							var actionURL = $("#SortableUploadField_File_" + fileID).data("action");
+							var actionURL = $("#"+ fieldID +"_File_"+ fileID).data("action");
 
-							$.get(actionURL, {
-								newPosition: (ui.item.index()),
-								oldPosition: ui.item.data("oldPosition")
-							}, function(data, status){
-								//window.console.log(data);
-							});
+							// actionURL won't be available in unsaved data-records.
+							// But since unsaved records don't need ajax sorting callbacks, it's fine to do
+							// nothing in case of a missing actionURL.
+							if(actionURL){
+								$.get(actionURL, {
+									newPosition: (ui.item.index()),
+									oldPosition: ui.item.data("oldPosition")
+								}, function(data, status){
+									//window.console.log(data);
+								});
+							}
 						}
 					});
 					this._super();

--- a/javascript/SortableUploadField.js
+++ b/javascript/SortableUploadField.js
@@ -6,12 +6,15 @@
 					// enable sorting functionality
 					var self = $(this);
 
+					// Get the action URL template (only thing that will change is the file ID).
+					var actionURL = $(this).siblings(".sortableupload-sortaction").data("action");
+
 					self.sortable({
 						handle: ".ss-uploadfield-item-preview",
 						axis: "y",
 						start: function(event, ui){
 							// remove overflow on container
-							ui.item.data("oldPosition", ui.item.index())
+							ui.item.data("oldPosition", ui.item.index());
 							self.css("overflow", "hidden");
 						},
 						stop: function(event, ui){
@@ -19,8 +22,6 @@
 							self.css("overflow", "auto");
 						},
 						update: function(event, ui){
-							// get the action URL
-							var actionURL = $(this).siblings(".sortableupload-sortaction").data("action");
 							// Get the current file ID
 							var fileID = ui.item.data("fileid");
 

--- a/javascript/SortableUploadField.js
+++ b/javascript/SortableUploadField.js
@@ -19,17 +19,16 @@
 							self.css("overflow", "auto");
 						},
 						update: function(event, ui){
-							// get the field ID from the actual upload field
-							var fieldID = $(this).parent().find("input.sortableupload").attr("id");
-							// Use the current file ID to determine a URL to the correct sort action handler.
+							// get the action URL
+							var actionURL = $(this).siblings(".sortableupload-sortaction").data("action");
+							// Get the current file ID
 							var fileID = ui.item.data("fileid");
-							var actionURL = $("#"+ fieldID +"_File_"+ fileID).data("action");
 
 							// actionURL won't be available in unsaved data-records.
 							// But since unsaved records don't need ajax sorting callbacks, it's fine to do
 							// nothing in case of a missing actionURL.
 							if(actionURL){
-								$.get(actionURL, {
+								$.get(actionURL.replace("{id}", fileID), {
 									newPosition: (ui.item.index()),
 									oldPosition: ui.item.data("oldPosition")
 								}, function(data, status){


### PR DESCRIPTION
I had another issue today where, when sorting files, the module wasn't always able to get the correct URL to post back and update the sort order asynchronously via AJAX. I realized that the method by which the module was doing this was by looking at the `data-href` attribute on the delete button. However, since we've had to add features to this area of the CMS (i.e. hiding the delete button to prevent the customer from accidentally deleting images which may be in use elsewhere within the system), this became quite problematic. Also this would happen if the current user didn't have permission to remove the button. 

Here's a fix!

**Primary benefits:**

* Fixes bugs that will arise when the current user doesn't have permissions to delete an image in the sorted list.
* Moving forward: Better separation of concerns (shouldn't contaminate other functionality and shouldn't be affected by customization of HTML contents outside of `SortableFileUpload`).