### PR TITLE
Avoid sorting with duplicates 

### DIFF
--- a/code/SortableUploadField.php
+++ b/code/SortableUploadField.php
@@ -100,7 +100,7 @@ class SortableUploadField extends UploadField
 
 	public function getItems() {
 		$items = parent::getItems();
-		return $items->sort($this->getSortColumn(), 'ASC');
+		return $items->sort(array($this->getSortColumn() => 'ASC', 'ID' => 'ASC'));
 	}
 
 	public function saveInto(DataObjectInterface $record) {


### PR DESCRIPTION
When for some reason there are duplicates in the SortOrder field, PHP crashes with the error:

    Fatal error:  Nesting level too deep - recursive dependency? in .../ArrayList.php on line 449

This has been reported against silverstripe/silverstripe-framework#4464.

When the above condition is triggered, the page instance hosting the SortableUploadField field becomes unaccessible from the CMS. This patch provides a patch (pun intended) to the problem by avoiding to have duplicates in the first place.